### PR TITLE
is_valid_path_for_dlopen函数 access 判断文件存在结果需要取非

### DIFF
--- a/third_party/opencl-stub/src/libopencl.cpp
+++ b/third_party/opencl-stub/src/libopencl.cpp
@@ -224,9 +224,9 @@ static bool is_valid_path_for_dlopen(const char* path) {
     if (strstr(path, ".framework") != NULL) {
         return true;
     }
-    return access(path, F_OK);
+    return !access(path, F_OK);
 #else
-    return access(path, F_OK);
+    return !access(path, F_OK);
 #endif
 }
 


### PR DESCRIPTION
`access(<path_to_file>, F_OK)` 返回值类型为 int ，如果文件<path_to_file>存在返回值为 0，否则返回值为 -1 。
函数 `is_valid_path_for_dlopen` 返回值为 bool ，将 access(<path_to_file>, F_OK) 返回值直接转为 bool 会得到相反的结果，因为 0 将被转为 false，-1 将被转为 true。
因此在函数 `open_shared_lib` 中，永远不会使用 `dlopen` 打开 default_so_paths 中真正存在的 .so 文件。
目前之所以可以正常运行，是因为配合 LD_LIBRARY_PATH 环境变量，在 default_so_paths 中最后一个不带绝对路径的 libOpenCL.so 可以被读取。 